### PR TITLE
feat(character_limit): handle longer oracle texts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 ### Added
 
 - new environment variable `DAILY_SCRY_IGNORED_ORACLE_IDS`. All oracle_id (seperated by `,`) in it will trigger a new random card, if chosen.
+- handle character limit for telegram and mastodon
 
 ### Changed
 

--- a/src/format.rs
+++ b/src/format.rs
@@ -367,7 +367,6 @@ fn vanguard_stats(builder: &mut Builder, card_or_face: &CardOrFace) {
 
 #[cfg(test)]
 mod tests {
-    // Note this useful idiom: importing names from outer (for mod tests) scope.
     use super::*;
 
     #[tokio::test]

--- a/src/main.rs
+++ b/src/main.rs
@@ -20,6 +20,7 @@ mod format;
 mod image;
 mod mastodon;
 mod telegram;
+mod util;
 
 #[tokio::main(flavor = "current_thread")]
 async fn main() -> Result<()> {
@@ -119,12 +120,14 @@ async fn post_to_mastodon(
     link: &str,
 ) -> Result<()> {
     debug!("creatiung mastodon post…");
-    let output = mastodon::post(&config, card_texts, artist, image_paths, link).await?;
+    let outputs = mastodon::post(&config, card_texts, artist, image_paths, link).await?;
 
-    match output {
-        PostStatusOutput::Status(status) => println!("Posted: {}", status.url.unwrap()),
-        PostStatusOutput::ScheduledStatus(scheduled_status) => {
-            println!("Will post at {}", scheduled_status.scheduled_at)
+    for output in outputs {
+        match output {
+            PostStatusOutput::Status(status) => println!("Posted: {}", status.url.unwrap()),
+            PostStatusOutput::ScheduledStatus(scheduled_status) => {
+                println!("Will post at {}", scheduled_status.scheduled_at)
+            }
         }
     }
     Ok(())

--- a/src/util.rs
+++ b/src/util.rs
@@ -1,0 +1,106 @@
+/*
+ * SPDX-FileCopyrightText: 2024 Philip Molares <philip.molares@udo.edu>
+ *
+ * SPDX-License-Identifier: MIT
+ */
+
+pub enum Additional {
+    Text(String),
+    Number(usize),
+}
+
+pub fn split_text(
+    text: String,
+    character_limit: usize,
+    additional_texts: Vec<Additional>,
+) -> Vec<String> {
+    let character_already_used = additional_texts
+        .into_iter()
+        .map(|additional| match additional {
+            Additional::Text(text) => text.len(),
+            Additional::Number(number) => number,
+        })
+        .fold(0, |accumulator, number| accumulator + number);
+    let number_of_characters = character_limit - character_already_used;
+
+    let mut texts = vec![];
+    let mut text_to_split = text.clone();
+    while text_to_split.len() > 0 {
+        if number_of_characters >= text_to_split.len() {
+            texts.push(text_to_split);
+            break;
+        }
+        texts.push(format!(
+            "{}{}",
+            text_to_split[..(number_of_characters - 1)].to_owned(),
+            "…".to_owned()
+        ));
+        text_to_split = text_to_split[number_of_characters - 1..].to_owned();
+    }
+    return texts;
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_limit_text_longer() {
+        let text = "0123456789".to_owned();
+        let result = split_text(text.clone(), 15, vec![]);
+        assert_eq!(result.len(), 1);
+        assert_eq!(result[0], text);
+    }
+
+    #[test]
+    fn test_limit_text_shorter() {
+        let text = "0123456789".to_owned();
+        let result = split_text(text.clone(), 5, vec![]);
+        assert_eq!(result.len(), 3);
+        assert_eq!(result[0], "0123…");
+        assert_eq!(result[1], "4567…");
+        assert_eq!(result[2], "89");
+    }
+
+    #[test]
+    fn test_limit_text_additional_only_text() {
+        let text = "0123456789".to_owned();
+        let result = split_text(
+            text.clone(),
+            10,
+            vec![Additional::Text("a".into()), Additional::Text("bc".into())],
+        );
+        assert_eq!(result.len(), 2);
+        assert_eq!(result[0], "012345…");
+        assert_eq!(result[1], "6789");
+    }
+
+    #[test]
+    fn test_limit_text_additional_only_number() {
+        let text = "0123456789".to_owned();
+        let result = split_text(
+            text.clone(),
+            10,
+            vec![Additional::Number(4), Additional::Number(3)],
+        );
+        assert_eq!(result.len(), 5);
+        assert_eq!(result[0], "01…");
+        assert_eq!(result[1], "23…");
+        assert_eq!(result[2], "45…");
+        assert_eq!(result[3], "67…");
+        assert_eq!(result[4], "89");
+    }
+    #[test]
+    fn test_limit_text_additional_mixed() {
+        let text = "0123456789".to_owned();
+        let result = split_text(
+            text.clone(),
+            10,
+            vec![Additional::Number(4), Additional::Text("a".into())],
+        );
+        assert_eq!(result.len(), 3);
+        assert_eq!(result[0], "0123…");
+        assert_eq!(result[1], "4567…");
+        assert_eq!(result[2], "89");
+    }
+}


### PR DESCRIPTION
If the oracle text ist longer than the character limit of the platform the text get's truncated and a `…` is added

Fixes #18 